### PR TITLE
chore: add missing repo-token input definition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
       reference regex."
     required: true
     default: "PR title failed to match %regex%."
+  repo-token:
+    description:
+      "Github token with access to the repository (secrets.GITHUB_TOKEN)."
+    required: true
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
Closes #90 