### PR TITLE
Add independent configurations for reviewing or failing the action on regex mismatch #GH-111

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: morrisoncole/pr-lint-action@feature/configure-failure-modes-GH-111
         with:
           title-regex: "#EX-[0-9]+"
-          on-failed-regex-fail-action: false
+          on-failed-regex-fail-action: true
           on-failed-regex-create-review: true
           on-failed-regex-comment: "Test. Failed regex: `%regex%`!"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,10 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: morrisoncole/pr-lint-action@main
+      - uses: morrisoncole/pr-lint-action@feature/configure-failure-modes-GH-111
         with:
-          title-regex: "#[eE][xX]-[0-9]+"
+          title-regex: "#EX-[0-9]+"
+          on-failed-regex-fail-action: false
+          on-failed-regex-create-review: true
+          on-failed-regex-comment: "Test. Failed regex: `%regex%`!"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           title-regex: "#EX-[0-9]+"
           on-failed-regex-fail-action: true
-          on-failed-regex-create-review: true
+          on-failed-regex-create-review: false
           on-failed-regex-comment: "Test. Failed regex: `%regex%`!"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,10 +12,11 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: morrisoncole/pr-lint-action@feature/configure-failure-modes-GH-111
+      - uses: morrisoncole/pr-lint-action@main
         with:
           title-regex: "#EX-[0-9]+"
-          on-failed-regex-fail-action: true
-          on-failed-regex-create-review: false
-          on-failed-regex-comment: "Test. Failed regex: `%regex%`!"
+          on-failed-regex-fail-action: false
+          on-failed-regex-create-review: true
+          on-failed-regex-comment:
+            "This is just an example. Failed regex: `%regex%`!"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ jobs:
   ability to specify whether to create a review and whether to fail the action
   on a regex mismatch independently with `on-failed-regex-fail-action` &
   `on-failed-regex-create-review`.
+- `on-failed-regex-comment` is no longer a required input.
+
+_Note:_ existing behaviour from previous releases is preserved without
+additional configuration 🙏.
 
 ### v1.2.3
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.3.0
         with:
-          title-regex: "#EX-[0-9]+"
+          title-regex: "#[eE][xX]-[0-9]+"
           on-failed-regex-fail-action: false
           on-failed-regex-create-review: true
           on-failed-regex-comment:
@@ -36,9 +36,10 @@ jobs:
 
 ### v1.3.0
 
-- Adds [#111](https://github.com/MorrisonCole/pr-lint-action/issues/111),
+- Adds [#111](https://github.com/MorrisonCole/pr-lint-action/issues/111), the
   ability to specify whether to create a review and whether to fail the action
-  on a regex mismatch independently.
+  on a regex mismatch independently with `on-failed-regex-fail-action` &
+  `on-failed-regex-create-review`.
 
 ### v1.2.3
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,20 @@ jobs:
       - uses: morrisoncole/pr-lint-action@v1.2.3
         with:
           title-regex: "#EX-[0-9]+"
+          on-failed-regex-create-review: true
           on-failed-regex-comment:
             "This is just an example. Failed regex: `%regex%`!"
+          on-failed-regex-fail-action: false
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
 ## Changelog
+
+### v1.3.0
+
+- Adds [#111](https://github.com/MorrisonCole/pr-lint-action/issues/111),
+  ability to specify whether to create a review and whether to fail the action
+  on a regex mismatch independently.
 
 ### v1.2.3
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: morrisoncole/pr-lint-action@v1.2.3
+      - uses: morrisoncole/pr-lint-action@v1.3.0
         with:
           title-regex: "#EX-[0-9]+"
+          on-failed-regex-fail-action: false
           on-failed-regex-create-review: true
           on-failed-regex-comment:
             "This is just an example. Failed regex: `%regex%`!"
-          on-failed-regex-fail-action: false
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Pull Request Linter"
-description: "Ensures your PR title matches a given regex"
+description: "Ensure your PR titles match a given regex."
 author: "MorrisonCole"
 branding:
   icon: "check"
@@ -9,12 +9,22 @@ inputs:
     description: "Regex to ensure PR title matches. Allows anything by default."
     required: true
     default: ".*"
+  on-failed-regex-create-review:
+    description:
+      "Whether the action should create a PR review & comment when the regex
+      doesn't match."
+    required: false
+    default: true
   on-failed-regex-comment:
     description:
       "Comment for the bot to post on PRs that fail the regex. Use %regex% to
       reference regex."
-    required: true
+    required: false
     default: "PR title failed to match %regex%."
+  on-failed-regex-fail-action:
+    description: "Whether the action should fail when the regex doesn't match."
+    required: false
+    default: false
   repo-token:
     description:
       "Github token with access to the repository (secrets.GITHUB_TOKEN)."

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,52 +2,85 @@ import { getOctokit } from "@actions/github/lib/github";
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 
+const repoTokenInput = core.getInput("repo-token", { required: true });
+const githubClient = getOctokit(repoTokenInput);
+
+const titleRegexInput: string = core.getInput("title-regex", {
+  required: true,
+});
+const onFailedRegexCreateReviewInput: boolean =
+  core.getInput("on-failed-regex-create-review") == "true";
+const onFailedRegexCommentInput: string = core.getInput(
+  "on-failed-regex-comment"
+);
+const onFailedRegexFailActionInput: boolean =
+  core.getInput("on-failed-regex-fail-action") == "true";
+
 async function run(): Promise<void> {
   const githubContext = github.context;
-  const githubToken = core.getInput("repo-token");
-  const githubClient = getOctokit(githubToken);
+  const pullRequest = githubContext.issue;
 
-  const pr = githubContext.issue;
-
-  const titleRegex = new RegExp(core.getInput("title-regex"));
+  const titleRegex = new RegExp(titleRegexInput);
   const title: string =
     (githubContext.payload.pull_request?.title as string) ?? "";
-
-  const onFailedRegexComment = core
-    .getInput("on-failed-regex-comment")
-    .replace("%regex%", titleRegex.source);
+  const comment = onFailedRegexCommentInput.replace(
+    "%regex%",
+    titleRegex.source
+  );
 
   core.debug(`Title Regex: ${titleRegex.source}`);
   core.debug(`Title: ${title}`);
 
   const titleMatchesRegex: boolean = titleRegex.test(title);
   if (!titleMatchesRegex) {
-    void githubClient.pulls.createReview({
-      owner: pr.owner,
-      repo: pr.repo,
-      pull_number: pr.number,
-      body: onFailedRegexComment,
-      event: "REQUEST_CHANGES",
-    });
+    if (onFailedRegexCreateReviewInput) {
+      createReview(comment, pullRequest);
+    }
+    if (onFailedRegexFailActionInput) {
+      core.setFailed(comment);
+    }
   } else {
-    const reviews = await githubClient.pulls.listReviews({
-      owner: pr.owner,
-      repo: pr.repo,
-      pull_number: pr.number,
-    });
-
-    reviews.data.forEach((review) => {
-      if (review.user.login == "github-actions[bot]") {
-        void githubClient.pulls.dismissReview({
-          owner: pr.owner,
-          repo: pr.repo,
-          pull_number: pr.number,
-          review_id: review.id,
-          message: "All good!",
-        });
-      }
-    });
+    if (onFailedRegexCreateReviewInput) {
+      await dismissReview(pullRequest);
+    }
   }
+}
+
+function createReview(
+  comment: string,
+  pullRequest: { owner: string; repo: string; number: number }
+) {
+  void githubClient.pulls.createReview({
+    owner: pullRequest.owner,
+    repo: pullRequest.repo,
+    pull_number: pullRequest.number,
+    body: comment,
+    event: "REQUEST_CHANGES",
+  });
+}
+
+async function dismissReview(pullRequest: {
+  owner: string;
+  repo: string;
+  number: number;
+}) {
+  const reviews = await githubClient.pulls.listReviews({
+    owner: pullRequest.owner,
+    repo: pullRequest.repo,
+    pull_number: pullRequest.number,
+  });
+
+  reviews.data.forEach((review) => {
+    if (review.user.login == "github-actions[bot]") {
+      void githubClient.pulls.dismissReview({
+        owner: pullRequest.owner,
+        repo: pullRequest.repo,
+        pull_number: pullRequest.number,
+        review_id: review.id,
+        message: "All good!",
+      });
+    }
+  });
 }
 
 run().catch((error) => {


### PR DESCRIPTION
Adds two new ways to configure the action for #111 

- `on-failed-regex-create-review`
- `on-failed-regex-fail-action`

Defaults preserve the existing action behaviour so as to not break anyone's workflows.