### PR TITLE
docs: correct version number in changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
 
 ## Changelog
 
-### v1.6.0
+### v1.6.1
 
 - Fixes [#266](https://github.com/MorrisonCole/pr-lint-action/issues/266): the
   success comment will now be created once the PR Lint succeeds, even when


### PR DESCRIPTION
## Describe your changes

- change the version number listed in README.md under Changelog
  - It seems "v1.6.0" was copy-pasted for the v1.6.1 log.