### PR TITLE
ci: don't run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
     #
     # Possible values: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
     types: [opened, edited, reopened, synchronize]
-  push:
-    branches:
-      - main
 
 jobs:
   pr-lint:


### PR DESCRIPTION
Don't need to run the test on main (there are no reviews to list/dismiss...)