### PR TITLE
chore: only run workflow on `example/*` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     #
     # Possible values: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
     types: [opened, edited, reopened, synchronize]
+    branches: ['example/**']
 
 jobs:
   pr-lint:
@@ -17,6 +18,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: 'dist/'
 
       - name: Test Action
         id: test-action

--- a/README.md
+++ b/README.md
@@ -185,12 +185,16 @@ being.
 
 ### Build & Package
 
-`yarn install`
+`yarn`
 
 `yarn build`
 
 `yarn package`: We package everything to a single file with Vercel's
 [ncc](https://github.com/vercel/ncc). Outputs to `dist/index.js`.
+
+### Testing the Action
+
+You can test the action by creating a PR with a `example/*` branch.
 
 ### Validate Renovate Config
 


### PR DESCRIPTION
* Only run workflow on `example/*` branches
* Use sparse checkout