### PR TITLE
Feat/upgrade node20 to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   pr-lint:
     name: Test PR Lint
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
 
 ## Changelog
 
-### 1.7.2
+### v1.7.2
 
 - Upgrade Node from 20 -> 24
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ jobs:
 
 ## Changelog
 
+### 1.7.2
+
+- Upgrade Node from 20 -> 24
+
 ### v1.7.1
 
 - Upgrade Node from 16 -> 20 ([thanks @sirLisko](https://github.com/MorrisonCole/pr-lint-action/pull/735)! 🙏).

--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
       "Github token with access to the repository (secrets.GITHUB_TOKEN)."
     required: true
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Summary
- Updates `action.yml` runtime from `node20` to `node24` ahead of GitHub's Node 20 deprecation (June 16, 2026)
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to CI to validate Node 24 compatibility now
- Adds v1.7.2 changelog entry to README

## Test Plan
- [ ] CI passes with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 active
- [ ] `action.yml` contains `using: "node24"`
- [ ] No `node20` references remain in config files