### PR TITLE
feat: update Node runtime to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
       "Github token with access to the repository (secrets.GITHUB_TOKEN)."
     required: true
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
BREAKING CHANGE: since this will fail on older GitHub Actions runners, the major version number should be bumped